### PR TITLE
Update MAX_PLAYERS Regardless of GENERATE_SETTINGS

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -20,5 +20,9 @@ elif [ "$GENERATE_SETTINGS" = "false" ]; then
   LogWarn "GENERATE_SETTINGS=false, not overwriting settings"
 fi
 
+# Always update MAX_PLAYERS setting regardless of GENERATE_SETTINGS
+LogAction "Updating MAX_PLAYERS setting"
+/home/steam/server/update-max-players.sh
+
 LogAction "Starting server"
 su steam -c "./FactoryServer.sh -Port=${GAME_PORT} -ini:Engine:[HTTPServer.Listeners]:DefaultBindAddress=any"

--- a/scripts/update-max-players.sh
+++ b/scripts/update-max-players.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# shellcheck source=scripts/functions.sh
+source "/home/steam/server/functions.sh"
+
+config_file="/satisfactory/FactoryGame/Saved/Config/LinuxServer/Game.ini"
+
+MAX_PLAYERS=${MAX_PLAYERS:-8}
+
+if [ -f "$config_file" ] && grep -q "^MaxPlayers=" "$config_file"; then
+    sed -i "s/^MaxPlayers=.*/MaxPlayers=$MAX_PLAYERS/" "$config_file"
+elif [ -f "$config_file" ] && grep -q "^\[/Script/Engine.GameSession\]" "$config_file"; then
+    sed -i "/^\[\/Script\/Engine.GameSession\]/a MaxPlayers=$MAX_PLAYERS" "$config_file"
+else
+    cat >> "$config_file" <<EOF
+
+[/Script/Engine.GameSession]
+MaxPlayers=$MAX_PLAYERS
+EOF
+fi


### PR DESCRIPTION
## Context <!-- markdownlint-disable MD041 -->
Max players being dependent on generating settings restricts users to 4 slots if not wanting to generate additional settings.
