### PR TITLE
fix: ensure FactoryServer.sh is executable after installation

### DIFF
--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -29,6 +29,7 @@ else
 fi
 
 chown -R steam:steam /satisfactory
+chmod +x /satisfactory/FactoryServer.sh
 
 # shellcheck disable=SC2317
 term_handler() {


### PR DESCRIPTION
### Description
This PR ensures that `FactoryServer.sh` has execute permissions (`+x`) set after installation, before the container attempts to run `start.sh`.

### Context & Cause
This issue was encountered while deploying the server inside an **unprivileged LXC container (running Docker) on Proxmox VE**. The container consistently crashed with:
`bash: line 1: ./FactoryServer.sh: Permission denied`

The root cause is that under unprivileged user namespaces and specific ZFS/mount policies, `DepotDownloader` (.NET Core) cannot natively write/set the Unix execution permissions (`+x`) on downloaded files. Because `init.sh` and `start.sh` do not explicitly run `chmod +x` on the newly downloaded `FactoryServer.sh` script, the container fails to launch the server.

### Solution
Adding `chmod +x /satisfactory/FactoryServer.sh` in `scripts/init.sh` right after the `install` process and ownership fix resolves the issue. This ensures the script is executable across all host directory mounts and container runtimes, making the image more robust.
